### PR TITLE
Fixed typographical error, changed aplication to application in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Container log monitoring
 (https://www.zabbix.com/documentation/2.4/manual/config/items/itemtypes/log_items) 
 can be used. Keep in mind, that Zabbix agent must support active mode for log 
 monitoring. Stdout/stderr Docker container console output is logged by Docker 
-into file */var/lib/docker/containers/<fid>/<fid>-json.log*. If the aplication 
+into file */var/lib/docker/containers/<fid>/<fid>-json.log*. If the application 
 in container is not able to log to stdout/stderr, link log file to  
 stdout/stderr. For example: 
 


### PR DESCRIPTION
@monitoringartist, I've corrected a typographical error in the documentation of the [Zabbix-Docker-Monitoring](https://github.com/monitoringartist/Zabbix-Docker-Monitoring) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.