### PR TITLE
Removed free(3) call that crashed Zabbix agent

### DIFF
--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -265,7 +265,6 @@ struct inspect_result     zbx_module_docker_inspect_exec(AGENT_REQUEST *request)
         free(query);
         if(strcmp(answer, "") == 0)
         {
-            free((void*) answer);
             zabbix_log(LOG_LEVEL_DEBUG, "docker.inspect is not available at the moment - some problem with Docker's socket API");
             iresult.value = zbx_strdup(NULL, "docker.inspect is not available at the moment - some problem with Docker's socket API");
             iresult.return_code = SYSINFO_RET_FAIL;


### PR DESCRIPTION
Line 268 in zabbix_module_docker.c crashes the Zabbix Agent because it calls `free(3)` on a pointer that references string constant `char *empty = ""` on line 152 in function `zbx_module_docker_socket_query`. Discovered while restarting Docker on a host with Zabbix Agent and plugin running. Removing the `free(3)` call fixes this.