### PR TITLE
v0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changes 0.6.7
-- cstatus, vstatus fix
-- removed official support for systemd - code moved to https://github.com/cavaliercoder/zabbix-module-systemd
+- fixed incorrect docker.cstatus/vstatus/istatus metric ([#74](https://github.com/monitoringartist/zabbix-docker-monitoring/issues/74))
+- removed support for systemd - code has been moved to https://github.com/cavaliercoder/zabbix-module-systemd
+- new item key docker.modver
 
 # Changes 0.6.6
 - fixed incorrect CPU multiplier in the template ([#30](https://github.com/monitoringartist/zabbix-docker-monitoring/issues/30)) - update your container CPU triggers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changes 0.6.7
+- cstatus, vstatus fix
+- removed official support for systemd - code moved to https://github.com/cavaliercoder/zabbix-module-systemd
+
 # Changes 0.6.6
 - fixed incorrect CPU multiplier in the template ([#30](https://github.com/monitoringartist/zabbix-docker-monitoring/issues/30)) - update your container CPU triggers
 - added total CPU utilization metric (current sum of user+system ticks)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changes 0.6.7
 - fixed incorrect docker.cstatus/vstatus/istatus metric ([#74](https://github.com/monitoringartist/zabbix-docker-monitoring/issues/74))
 - removed support for systemd - code has been moved to https://github.com/cavaliercoder/zabbix-module-systemd
+- added timeout for Docker socket query ([#73](https://github.com/monitoringartist/zabbix-docker-monitoring/issues/73))
 - new item key docker.modver
 
 # Changes 0.6.6

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Note: cid - container ID, two options are available:
 | **docker.istatus[status]** | **Count of Docker images in defined status:**<br>**status** - image status, available statuses:<br>*All* - all images<br>*Dangling* - count of dangling images<br>Note: [Additional Docker permissions](#additional-docker-permissions) are needed.|
 | **docker.vstatus[status]** | **Count of Docker volumes in defined status:**<br>**status** - volume status, available statuses:<br>*All* - all volumes<br>*Dangling* - count of dangling volumes<br>Note 1: [Additional Docker permissions](#additional-docker-permissions) are needed.<br>Note2: Docker API v1.21+ is required|
 | **docker.up[cid]** | **Running state check:**<br>1 if container is running, otherwise 0 |
+| **docker.modver** | **Version of the loaded docker module** |
 | | |
 | **docker.xnet[cid,interface,nmetric]** | **Network metrics (experimental):**<br>**interface** - name of interface, e.g. eth0, if name is *all*, then sum of selected metric across all interfaces is returned (lo included)<br>**nmetric** - any available network metric name from output of command netstat -i:<br>*MTU, Met, RX-OK, RX-ERR, RX-DRP, RX-OVR, TX-OK, TX-ERR, TX-DRP, TX-OVR*<br>For example:<br>*docker.xnet[cid,eth0,TX-OK]<br>docker.xnet[cid,all,RX-ERR]*<br>Note: [Root permissions (AllowRoot=1)](#additional-docker-permissions) are required, because net namespaces (/var/run/netns/) are created/used|
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [<img src="https://monitoringartist.github.io/managed-by-monitoringartist.png" alt="Managed by Monitoring Artist: DevOps / Docker / Kubernetes / AWS ECS / Zabbix / Zenoss / Terraform / Monitoring" align="right"/>](http://www.monitoringartist.com 'DevOps / Docker / Kubernetes / AWS ECS / Zabbix / Zenoss / Terraform / Monitoring')
 
-# Zabbix Docker Monitoring
+# Zabbix Docker Monitoring [![Build Status](https://travis-ci.org/monitoringartist/zabbix-docker-monitoring.svg?branch=master)](https://travis-ci.org/monitoringartist/zabbix-docker-monitoring)
 
 If you like or use this project, please provide feedback to author - Star it ★
 and [write what's missing for you](https://docs.google.com/forms/d/e/1FAIpQLSdYIokAyIMs2Qv19fzPxMWBubS9ESOYjJ2w_P222k5SuQuvoA/viewform).
@@ -27,7 +27,7 @@ Module is focused on the performance, see section
 
 Module is available also as a part of another project - Docker image
 [dockbix-agent-xxl-limited](https://hub.docker.com/r/monitoringartist/dockbix-agent-xxl-limited/)
-(OS Linux host metrics are supported as well). Quick start:
+(OS Linux host metrics and other selected metrics are supported as well). Quick start:
 
 [![Dockbix Agent XXL Docker container](https://raw.githubusercontent.com/monitoringartist/dockbix-agent-xxl/master/doc/dockbix-agent-xxl.gif)](https://github.com/monitoringartist/dockbix-agent-xxl)
 
@@ -74,7 +74,7 @@ docker run --rm \
   monitoringartist/zabbix-templates
 ```
 
-Download latest build of `zabbix_module_docker.so` for Zabbix 3.2/3.0 agents [![Build Status](https://travis-ci.org/monitoringartist/zabbix-docker-monitoring.svg?branch=master)](https://travis-ci.org/monitoringartist/zabbix-docker-monitoring):
+Download latest build of `zabbix_module_docker.so` for Zabbix 3.2/3.0 agents:
 
 | OS           | Docker module for Zabbix 3.2  | Docker module for Zabbix 3.0   |
 | ------------ | :---------------------------: | :----------------------------: |
@@ -93,7 +93,7 @@ Download latest build of `zabbix_module_docker.so` for Zabbix 3.2/3.0 agents [![
 | Ubuntu 14    | [Download](https://github.com/monitoringartist/zabbix-docker-monitoring/raw/gh-pages/ubuntu14/3.2/zabbix_module_docker.so) | [Download](https://github.com/monitoringartist/zabbix-docker-monitoring/raw/gh-pages/ubuntu14/3.0/zabbix_module_docker.so) |
 
 If provided build doesn't work on your system, please see section [Compilation](#compilation).
-Or you can check [folder dockerfiles](https://github.com/monitorinartist/zabbix-docker-monitoring/tree/master/dockerfiles),
+Or you can check [folder dockerfiles](https://github.com/monitoringartist/zabbix-docker-monitoring/tree/master/dockerfiles),
 where Dockerfiles for different OS/Zabbix versions can be customized.
 
 # Grafana dashboard
@@ -126,7 +126,7 @@ Note: cid - container ID, two options are available:
 | **docker.up[cid]** | **Running state check:**<br>1 if container is running, otherwise 0 |
 | **docker.modver** | **Version of the loaded docker module** |
 | | |
-| **docker.xnet[cid,interface,nmetric]** | **Network metrics (experimental):**<br>**interface** - name of interface, e.g. eth0, if name is *all*, then sum of selected metric across all interfaces is returned (lo included)<br>**nmetric** - any available network metric name from output of command netstat -i:<br>*MTU, Met, RX-OK, RX-ERR, RX-DRP, RX-OVR, TX-OK, TX-ERR, TX-DRP, TX-OVR*<br>For example:<br>*docker.xnet[cid,eth0,TX-OK]<br>docker.xnet[cid,all,RX-ERR]*<br>Note: [Root permissions (AllowRoot=1)](#additional-docker-permissions) are required, because net namespaces (/var/run/netns/) are created/used|
+| **docker.xnet[cid,interface,nmetric]** | **Network metrics (experimental):**<br>**interface** - name of interface, e.g. eth0, if name is *all*, then sum of selected metric across all interfaces is returned (`lo` included)<br>**nmetric** - any available network metric name from output of command netstat -i:<br>*MTU, Met, RX-OK, RX-ERR, RX-DRP, RX-OVR, TX-OK, TX-ERR, TX-DRP, TX-OVR*<br>For example:<br>*docker.xnet[cid,eth0,TX-OK]<br>docker.xnet[cid,all,RX-ERR]*<br>Note: [Root permissions (AllowRoot=1)](#additional-docker-permissions) are required, because net namespaces (`/var/run/netns/`) are created/used|
 
 Container log monitoring
 ========================
@@ -185,7 +185,7 @@ You have two options, how to get additional Docker permissions:
 usermod -aG docker zabbix
 ```
 
-Or
+**Or**
 
 - Edit zabbix_agentd.conf and set AllowRoot (Zabbix agent with root
 permissions):
@@ -363,7 +363,7 @@ Part of config in zabbix_agentd.conf:
     UserParameter=xdocker.discovery,/etc/zabbix/scripts/container_discover.sh
     LoadModule=zabbix_module_docker.so
 
-[container_discover.sh](https://github.com/bsmile/zabbix-docker-lld/blob/master/usr/lib/zabbix/script/container_discover.sh):
+Shell implementation container_discover.sh:
 
 Test with 237 running containers:
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Note: cid - container ID, two options are available:
 | **docker.istatus[status]** | **Count of Docker images in defined status:**<br>**status** - image status, available statuses:<br>*All* - all images<br>*Dangling* - count of dangling images<br>Note: [Additional Docker permissions](#additional-docker-permissions) are needed.|
 | **docker.vstatus[status]** | **Count of Docker volumes in defined status:**<br>**status** - volume status, available statuses:<br>*All* - all volumes<br>*Dangling* - count of dangling volumes<br>Note 1: [Additional Docker permissions](#additional-docker-permissions) are needed.<br>Note2: Docker API v1.21+ is required|
 | **docker.up[cid]** | **Running state check:**<br>1 if container is running, otherwise 0 |
-| **docker.modver** | **Version of the loaded docker module** |
+| **docker.modver** | Version of the loaded docker module |
 | | |
 | **docker.xnet[cid,interface,nmetric]** | **Network metrics (experimental):**<br>**interface** - name of interface, e.g. eth0, if name is *all*, then sum of selected metric across all interfaces is returned (`lo` included)<br>**nmetric** - any available network metric name from output of command netstat -i:<br>*MTU, Met, RX-OK, RX-ERR, RX-DRP, RX-OVR, TX-OK, TX-ERR, TX-DRP, TX-OVR*<br>For example:<br>*docker.xnet[cid,eth0,TX-OK]<br>docker.xnet[cid,all,RX-ERR]*<br>Note: [Root permissions (AllowRoot=1)](#additional-docker-permissions) are required, because net namespaces (`/var/run/netns/`) are created/used|
 

--- a/README.md
+++ b/README.md
@@ -127,12 +127,6 @@ Note: cid - container ID, two options are available:
 | | |
 | **docker.xnet[cid,interface,nmetric]** | **Network metrics (experimental):**<br>**interface** - name of interface, e.g. eth0, if name is *all*, then sum of selected metric across all interfaces is returned (lo included)<br>**nmetric** - any available network metric name from output of command netstat -i:<br>*MTU, Met, RX-OK, RX-ERR, RX-DRP, RX-OVR, TX-OK, TX-ERR, TX-DRP, TX-OVR*<br>For example:<br>*docker.xnet[cid,eth0,TX-OK]<br>docker.xnet[cid,all,RX-ERR]*<br>Note: [Root permissions (AllowRoot=1)](#additional-docker-permissions) are required, because net namespaces (/var/run/netns/) are created/used|
 
-Maybe in the future:
-
-- systemd.net - net metrics of systemd units
-- systemd.log - log monitoring of systemd units
-- docker.cpu - collector implementation
-
 Container log monitoring
 ========================
 

--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -2026,20 +2026,20 @@ int     zbx_module_docker_cstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
         {
             // Up
             const char *answer = zbx_module_docker_socket_query("GET /containers/json?all=0 HTTP/1.0\r\n\n", 0);
+            int count = 0;
+
             if(strcmp(answer, "") == 0)
             {
                 zabbix_log(LOG_LEVEL_DEBUG, "docker.cstatus is not available at the moment - some problem with Docker's socket API");
                 SET_MSG_RESULT(result, strdup("docker.cstatus is not available at the moment - some problem with Docker's socket API"));
                 return SYSINFO_RET_FAIL;
             }
-            if(strcmp(answer, "[]\n") == 0)
+            if(strcmp(answer, "[]\n") != 0)
             {
-                int count = 0;
-            } else {
                 struct zbx_json_parse	jp_data;
                 jp_data.start = &answer[0];
                 jp_data.end = &answer[strlen(answer)];
-                int count = zbx_json_count(&jp_data);
+                count = zbx_json_count(&jp_data);
             }
             free((void*) answer);
             zabbix_log(LOG_LEVEL_DEBUG, "Count of containers in %s status: %d", state, count);
@@ -2052,20 +2052,20 @@ int     zbx_module_docker_cstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
                 // Exited = All - Up
                 // # All
                 const char *answer = zbx_module_docker_socket_query("GET /containers/json?all=1 HTTP/1.0\r\n\n", 0);
+                struct zbx_json_parse	jp_data;
+                int count = 0;
+
                 if(strcmp(answer, "") == 0)
                 {
                     zabbix_log(LOG_LEVEL_DEBUG, "docker.cstatus is not available at the moment - some problem with Docker's socket API");
                     SET_MSG_RESULT(result, strdup("docker.cstatus is not available at the moment - some problem with Docker's socket API"));
                     return SYSINFO_RET_FAIL;
                 }
-                if(strcmp(answer, "[]\n") == 0)
+                if(strcmp(answer, "[]\n") != 0)
                 {
-                    int count = 0;
-                } else {
-                    struct zbx_json_parse	jp_data;
                     jp_data.start = &answer[0];
                     jp_data.end = &answer[strlen(answer)];
-                    int count = zbx_json_count(&jp_data);
+                    count = zbx_json_count(&jp_data);
                 }
                 free((void*) answer);
 
@@ -2077,10 +2077,8 @@ int     zbx_module_docker_cstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
                     SET_MSG_RESULT(result, strdup("docker.cstatus is not available at the moment - some problem with Docker's socket API"));
                     return SYSINFO_RET_FAIL;
                 }
-                if(strcmp(answer2, "[]\n") == 0)
+                if(strcmp(answer2, "[]\n") != 0)
                 {
-                    count = 0;
-                } else {
                     jp_data.start = &answer2[0];
                     jp_data.end = &answer2[strlen(answer2)];
                     count = count - zbx_json_count(&jp_data);
@@ -2153,20 +2151,19 @@ int     zbx_module_docker_cstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
                     {
                         // All
                         const char *answer = zbx_module_docker_socket_query("GET /containers/json?all=1 HTTP/1.0\r\n\n", 0);
+                        int count = 0;
                         if(strcmp(answer, "") == 0)
                         {
                             zabbix_log(LOG_LEVEL_DEBUG, "docker.cstatus is not available at the moment - some problem with Docker's socket API");
                             SET_MSG_RESULT(result, strdup("docker.cstatus is not available at the moment - some problem with Docker's socket API"));
                             return SYSINFO_RET_FAIL;
                         }
-                        if(strcmp(answer, "[]\n") == 0)
+                        if(strcmp(answer, "[]\n") != 0)
                         {
-                            int count = 0;
-                        } else {
                             struct zbx_json_parse	jp_data;
                             jp_data.start = &answer[0];
                             jp_data.end = &answer[strlen(answer)];
-                            int count = zbx_json_count(&jp_data);
+                            count = zbx_json_count(&jp_data);
                         }
                         free((void*) answer);
                         zabbix_log(LOG_LEVEL_DEBUG, "Count of containers in %s status: %d", state, count);

--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -61,7 +61,6 @@ int     zbx_module_docker_mem(AGENT_REQUEST *request, AGENT_RESULT *result);
 int     zbx_module_docker_cpu(AGENT_REQUEST *request, AGENT_RESULT *result);
 int     zbx_module_docker_net(AGENT_REQUEST *request, AGENT_RESULT *result);
 int     zbx_module_docker_dev(AGENT_REQUEST *request, AGENT_RESULT *result);
-int     zbx_module_systemd_discovery(AGENT_REQUEST *request, AGENT_RESULT *result);
 
 static ZBX_METRIC keys[] =
 /*      KEY                     FLAG            FUNCTION                TEST PARAMETERS */
@@ -78,11 +77,6 @@ static ZBX_METRIC keys[] =
         {"docker.cpu",  CF_HAVEPARAMS,  zbx_module_docker_cpu,  "full container id, cpu metric name"},
         {"docker.xnet", CF_HAVEPARAMS,  zbx_module_docker_net,  "full container id, interface, network metric name"},
         {"docker.dev",  CF_HAVEPARAMS,  zbx_module_docker_dev,  "full container id, blkio file, blkio metric name"},
-        {"systemd.discovery", CF_HAVEPARAMS, zbx_module_systemd_discovery,    "parameter 1"},
-        {"systemd.mem",  CF_HAVEPARAMS,  zbx_module_docker_mem,  "full unit id, memory metric name"},
-        {"systemd.cpu",  CF_HAVEPARAMS,  zbx_module_docker_cpu,  "full unit id, cpu metric name"},
-        {"systemd.up",   CF_HAVEPARAMS,  zbx_module_docker_up,   "full unit id"},
-        {"systemd.dev",  CF_HAVEPARAMS,  zbx_module_docker_dev,  "full unit id, blkio file, blkio metric name"},
         {NULL}
 };
 
@@ -680,8 +674,8 @@ int     zbx_module_docker_up(AGENT_REQUEST *request, AGENT_RESULT *result)
 
         if (stat_dir == NULL || driver == NULL)
         {
-                zabbix_log(LOG_LEVEL_DEBUG, "docker.up/systemd.up check is not available at the moment - no stat directory");
-                SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.up/systemd.up check is not available at the moment - no stat directory"));
+                zabbix_log(LOG_LEVEL_DEBUG, "docker.up check is not available at the moment - no stat directory");
+                SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.up check is not available at the moment - no stat directory"));
                 return SYSINFO_RET_FAIL;
         }
 
@@ -689,8 +683,8 @@ int     zbx_module_docker_up(AGENT_REQUEST *request, AGENT_RESULT *result)
         {
                 if (zbx_docker_dir_detect() == SYSINFO_RET_FAIL)
                 {
-                    zabbix_log(LOG_LEVEL_DEBUG, "docker.up/systemd.up check is not available at the moment - no cpu_cgroup directory");
-                    SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.up/systemd.up check is not available at the moment - no cpu_cgroup directory"));
+                    zabbix_log(LOG_LEVEL_DEBUG, "docker.up check is not available at the moment - no cpu_cgroup directory");
+                    SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.up check is not available at the moment - no cpu_cgroup directory"));
                     return SYSINFO_RET_FAIL;
                 }
         }
@@ -767,8 +761,8 @@ int     zbx_module_docker_dev(AGENT_REQUEST *request, AGENT_RESULT *result)
 
         if (stat_dir == NULL || driver == NULL)
         {
-                zabbix_log(LOG_LEVEL_DEBUG, "docker.dev/systemd.dev metrics are not available at the moment - no stat directory");
-                SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.dev/systemd.dev metrics are not available at the moment - no stat directory"));
+                zabbix_log(LOG_LEVEL_DEBUG, "docker.dev metrics are not available at the moment - no stat directory");
+                SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.dev metrics are not available at the moment - no stat directory"));
                 return SYSINFO_RET_FAIL;
         }
 
@@ -880,8 +874,8 @@ int     zbx_module_docker_mem(AGENT_REQUEST *request, AGENT_RESULT *result)
 
         if (stat_dir == NULL || driver == NULL)
         {
-                zabbix_log(LOG_LEVEL_DEBUG, "docker.mem/systemd.mem metrics are not available at the moment - no stat directory");
-                SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.mem/systemd.mem metrics are not available at the moment - no stat directory"));
+                zabbix_log(LOG_LEVEL_DEBUG, "docker.mem metrics are not available at the moment - no stat directory");
+                SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.mem metrics are not available at the moment - no stat directory"));
                 return SYSINFO_RET_FAIL;
         }
 
@@ -987,8 +981,8 @@ int     zbx_module_docker_cpu(AGENT_REQUEST *request, AGENT_RESULT *result)
 
         if (stat_dir == NULL || driver == NULL)
         {
-                zabbix_log(LOG_LEVEL_DEBUG, "docker.cpu/systemd.cpu metrics are not available at the moment - no stat directory");
-                SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.cpu/systemd.cpu metrics are not available at the moment - no stat directory"));
+                zabbix_log(LOG_LEVEL_DEBUG, "docker.cpu metrics are not available at the moment - no stat directory");
+                SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.cpu metrics are not available at the moment - no stat directory"));
                 return SYSINFO_RET_FAIL;
         }
 
@@ -996,8 +990,8 @@ int     zbx_module_docker_cpu(AGENT_REQUEST *request, AGENT_RESULT *result)
         {
                 if (zbx_docker_dir_detect() == SYSINFO_RET_FAIL)
                 {
-                    zabbix_log(LOG_LEVEL_DEBUG, "docker.cpu/systemd.cpu check is not available at the moment - no cpu_cgroup directory");
-                    SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.cpu/systemd.cpu check is not available at the moment - no cpu_cgroup directory"));
+                    zabbix_log(LOG_LEVEL_DEBUG, "docker.cpu check is not available at the moment - no cpu_cgroup directory");
+                    SET_MSG_RESULT(result, zbx_strdup(NULL, "docker.cpu check is not available at the moment - no cpu_cgroup directory"));
                     return SYSINFO_RET_FAIL;
                 }
         }
@@ -2407,124 +2401,4 @@ int     zbx_module_docker_vstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
         zabbix_log(LOG_LEVEL_DEBUG, "Not supported volume state: %s", state);
         SET_MSG_RESULT(result, strdup("Not supported volume state"));
         return SYSINFO_RET_FAIL;
-}
-
-/******************************************************************************
- *                                                                            *
- * Function: zbx_module_systemd_discovery                                *
- *                                                                            *
- * Purpose: systemd discovery                                               *
- *                                                                            *
- * Return value: SYSINFO_RET_FAIL - function failed, item will be marked      *
- *                                 as not supported by zabbix                 *
- *               SYSINFO_RET_OK - success                                     *
- *                                                                            *
- ******************************************************************************/
-int     zbx_module_systemd_discovery(AGENT_REQUEST *request, AGENT_RESULT *result)
-{
-        zabbix_log(LOG_LEVEL_DEBUG, "In zbx_module_systemd_discovery()");
-        char    *type;
-
-        struct zbx_json j;
-        if(strcmp(driver, "system.slice/") != 0) {
-            zabbix_log(LOG_LEVEL_WARNING, "systemd was not detected");
-            zbx_json_init(&j, ZBX_JSON_STAT_BUF_LEN);
-            zbx_json_addarray(&j, ZBX_PROTO_TAG_DATA);
-            zbx_json_close(&j);
-            SET_MSG_RESULT(result, zbx_strdup(NULL, "Systemd was not detected"));
-            zbx_json_free(&j);
-            return SYSINFO_RET_FAIL;
-        }
-
-        if (1 != request->nparam)
-        {
-                zabbix_log(LOG_LEVEL_ERR, "Invalid number of parameters: %d",  request->nparam);
-                SET_MSG_RESULT(result, strdup("Invalid number of parameters"));
-                return SYSINFO_RET_FAIL;
-        }
-
-        if(stat_dir == NULL && zbx_docker_dir_detect() == SYSINFO_RET_FAIL)
-        {
-            zabbix_log(LOG_LEVEL_DEBUG, "systemd.discovery is not available at the moment - no stat directory - empty discovery");
-            zbx_json_init(&j, ZBX_JSON_STAT_BUF_LEN);
-            zbx_json_addarray(&j, ZBX_PROTO_TAG_DATA);
-            zbx_json_close(&j);
-            SET_STR_RESULT(result, zbx_strdup(NULL, j.buffer));
-            zbx_json_free(&j);
-            return SYSINFO_RET_FAIL;
-        }
-
-        DIR             *dir;
-        zbx_stat_t      sb;
-        char            *file = NULL, *dot, *hid;
-        struct dirent   *d;
-        char    *cgroup = cpu_cgroup;
-        size_t  ddir_size = strlen(cpu_cgroup) + strlen(stat_dir) + strlen(driver) + 2;
-        char    *ddir = malloc(ddir_size);
-        zbx_strlcpy(ddir, stat_dir, ddir_size);
-        zbx_strlcat(ddir, cgroup, ddir_size);
-        zbx_strlcat(ddir, driver, ddir_size);
-
-        if (NULL == (dir = opendir(ddir)))
-        {
-            zabbix_log(LOG_LEVEL_WARNING, "%s: %s", ddir, zbx_strerror(errno));
-            free(ddir);
-            return SYSINFO_RET_FAIL;
-        }
-
-        zbx_json_init(&j, ZBX_JSON_STAT_BUF_LEN);
-        zbx_json_addarray(&j, ZBX_PROTO_TAG_DATA);
-
-        size_t type_size = strlen(get_rparam(request, 0)) + 2;
-        type = malloc(type_size);
-        zbx_strlcpy(type, ".", type_size);
-        zbx_strlcat(type, get_rparam(request, 0), type_size);
-
-        while (NULL != (d = readdir(dir)))
-        {
-                if(0 == strcmp(d->d_name, ".") || 0 == strcmp(d->d_name, ".."))
-                        continue;
-
-                file = zbx_dsprintf(file, "%s/%s", ddir, d->d_name);
-
-                if (0 != zbx_stat(file, &sb) || 0 == S_ISDIR(sb.st_mode))
-                        continue;
-
-                // end '.service'
-                dot = strrchr(d->d_name, '.');
-                if (dot == NULL || strcmp(dot, type) != 0) {
-                    continue;
-                }
-
-                hid = NULL;
-                hid = malloc(strlen(d->d_name));
-                zbx_strlcpy(hid, d->d_name, strlen(d->d_name));
-                // remove suffix (.type)
-                hid = strtok(hid, ".");
-                // remove preffix (systemd-)
-                if (strncmp(hid, "systemd-", strlen("systemd-")) == 0) {
-                    hid += strlen("systemd-");
-                }
-
-                zbx_json_addobject(&j, NULL);
-                zbx_json_addstring(&j, "{#FID}", d->d_name, ZBX_JSON_TYPE_STRING);
-                zbx_json_addstring(&j, "{#HID}", hid, ZBX_JSON_TYPE_STRING);
-                zbx_json_close(&j);
-        }
-
-        if(0 != closedir(dir))
-        {
-            zabbix_log(LOG_LEVEL_WARNING, "%s: %s\n", ddir, zbx_strerror(errno));
-        }
-
-        zbx_json_close(&j);
-
-        SET_STR_RESULT(result, zbx_strdup(NULL, j.buffer));
-
-        zbx_json_free(&j);
-
-        free(ddir);
-        free(type);
-
-        return SYSINFO_RET_OK;
 }

--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -2264,21 +2264,26 @@ int     zbx_module_docker_istatus(AGENT_REQUEST *request, AGENT_RESULT *result)
 
         char    *state;
         state = get_rparam(request, 0);
+        struct zbx_json_parse	jp_data;
+        int count = 0;
 
         if (strcmp(state, "All") == 0)
         {
             // All
             const char *answer = zbx_module_docker_socket_query("GET /images/json?all=1&dangling=true HTTP/1.0\r\n\n", 0);
+
             if(strcmp(answer, "") == 0)
             {
                 zabbix_log(LOG_LEVEL_DEBUG, "docker.istatus is not available at the moment - some problem with Docker's socket API");
                 SET_MSG_RESULT(result, strdup("docker.istatus is not available at the moment - some problem with Docker's socket API"));
                 return SYSINFO_RET_FAIL;
             }
-            struct zbx_json_parse	jp_data;
-            jp_data.start = &answer[0];
-            jp_data.end = &answer[strlen(answer)];
-            int count = zbx_json_count(&jp_data);
+            if(strcmp(answer, "[]\n") != 0)
+            {
+                jp_data.start = &answer[0];
+                jp_data.end = &answer[strlen(answer)];
+                count = zbx_json_count(&jp_data);
+            }
             free((void*) answer);
             zabbix_log(LOG_LEVEL_DEBUG, "Count of images in %s status: %d", state, count);
             SET_UI64_RESULT(result, count);
@@ -2292,10 +2297,12 @@ int     zbx_module_docker_istatus(AGENT_REQUEST *request, AGENT_RESULT *result)
                 SET_MSG_RESULT(result, strdup("docker.istatus is not available at the moment - some problem with Docker's socket API"));
                 return SYSINFO_RET_FAIL;
             }
-            struct zbx_json_parse	jp_data;
-            jp_data.start = &answer[0];
-            jp_data.end = &answer[strlen(answer)];
-            int count = zbx_json_count(&jp_data);
+            if(strcmp(answer, "[]\n") != 0)
+            {
+                jp_data.start = &answer[0];
+                jp_data.end = &answer[strlen(answer)];
+                count = zbx_json_count(&jp_data);
+            }
             free((void*) answer);
             zabbix_log(LOG_LEVEL_DEBUG, "Count of images in %s status: %d", state, count);
             SET_UI64_RESULT(result, count);

--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -47,7 +47,7 @@ struct inspect_result
 };
 struct timeval stimeout;
 
-char    *m_version = "v0.6.6";
+char    *m_version = "v0.6.7";
 char    *stat_dir = NULL, *driver, *c_prefix = NULL, *c_suffix = NULL, *cpu_cgroup = NULL, *hostname = 0;
 static int item_timeout = 1, buffer_size = 1024, cid_length = 66, socket_api;
 int     zbx_module_docker_discovery(AGENT_REQUEST *request, AGENT_RESULT *result);
@@ -62,6 +62,7 @@ int     zbx_module_docker_mem(AGENT_REQUEST *request, AGENT_RESULT *result);
 int     zbx_module_docker_cpu(AGENT_REQUEST *request, AGENT_RESULT *result);
 int     zbx_module_docker_net(AGENT_REQUEST *request, AGENT_RESULT *result);
 int     zbx_module_docker_dev(AGENT_REQUEST *request, AGENT_RESULT *result);
+int     zbx_module_docker_modver(AGENT_REQUEST *request, AGENT_RESULT *result);
 
 static ZBX_METRIC keys[] =
 /*      KEY                     FLAG            FUNCTION                TEST PARAMETERS */
@@ -78,6 +79,7 @@ static ZBX_METRIC keys[] =
         {"docker.cpu",  CF_HAVEPARAMS,  zbx_module_docker_cpu,  "full container id, cpu metric name"},
         {"docker.xnet", CF_HAVEPARAMS,  zbx_module_docker_net,  "full container id, interface, network metric name"},
         {"docker.dev",  CF_HAVEPARAMS,  zbx_module_docker_dev,  "full container id, blkio file, blkio metric name"},
+        {"docker.modver",  CF_HAVEPARAMS,  zbx_module_docker_modver},
         {NULL}
 };
 
@@ -2435,4 +2437,22 @@ int     zbx_module_docker_vstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
         zabbix_log(LOG_LEVEL_DEBUG, "Not supported volume state: %s", state);
         SET_MSG_RESULT(result, strdup("Not supported volume state"));
         return SYSINFO_RET_FAIL;
+}
+
+/******************************************************************************
+ *                                                                            *
+ * Function: zbx_module_docker_modver                                         *
+ *                                                                            *
+ * Purpose: return current docker module version                              *
+ *                                                                            *
+ * Return value: SYSINFO_RET_FAIL - function failed, item will be marked      *
+ *                                 as not supported by zabbix                 *
+ *               SYSINFO_RET_OK - success                                     *
+ *                                                                            *
+ ******************************************************************************/
+int     zbx_module_docker_modver(AGENT_REQUEST *request, AGENT_RESULT *result)
+{
+        zabbix_log(LOG_LEVEL_DEBUG, "In zbx_module_docker_modver()");
+        SET_STR_RESULT(result, zbx_strdup(NULL, m_version));
+        return SYSINFO_RET_OK;
 }

--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -2032,14 +2032,20 @@ int     zbx_module_docker_cstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
                 SET_MSG_RESULT(result, strdup("docker.cstatus is not available at the moment - some problem with Docker's socket API"));
                 return SYSINFO_RET_FAIL;
             }
-            struct zbx_json_parse	jp_data;
-            jp_data.start = &answer[0];
-            jp_data.end = &answer[strlen(answer)];
-            int count = zbx_json_count(&jp_data);
+            if(strcmp(answer, "[]\n") == 0)
+            {
+                int count = 0;
+            } else {
+                struct zbx_json_parse	jp_data;
+                jp_data.start = &answer[0];
+                jp_data.end = &answer[strlen(answer)];
+                int count = zbx_json_count(&jp_data);
+            }
             free((void*) answer);
             zabbix_log(LOG_LEVEL_DEBUG, "Count of containers in %s status: %d", state, count);
             SET_UI64_RESULT(result, count);
             return SYSINFO_RET_OK;
+
         } else {
             if (strcmp(state, "Exited") == 0)
             {
@@ -2052,10 +2058,15 @@ int     zbx_module_docker_cstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
                     SET_MSG_RESULT(result, strdup("docker.cstatus is not available at the moment - some problem with Docker's socket API"));
                     return SYSINFO_RET_FAIL;
                 }
-                struct zbx_json_parse	jp_data;
-                jp_data.start = &answer[0];
-                jp_data.end = &answer[strlen(answer)];
-                int count = zbx_json_count(&jp_data);
+                if(strcmp(answer, "[]\n") == 0)
+                {
+                    int count = 0;
+                } else {
+                    struct zbx_json_parse	jp_data;
+                    jp_data.start = &answer[0];
+                    jp_data.end = &answer[strlen(answer)];
+                    int count = zbx_json_count(&jp_data);
+                }
                 free((void*) answer);
 
                 // # Up
@@ -2066,9 +2077,14 @@ int     zbx_module_docker_cstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
                     SET_MSG_RESULT(result, strdup("docker.cstatus is not available at the moment - some problem with Docker's socket API"));
                     return SYSINFO_RET_FAIL;
                 }
-                jp_data.start = &answer2[0];
-                jp_data.end = &answer2[strlen(answer2)];
-                count = count - zbx_json_count(&jp_data);
+                if(strcmp(answer2, "[]\n") == 0)
+                {
+                    count = 0;
+                } else {
+                    jp_data.start = &answer2[0];
+                    jp_data.end = &answer2[strlen(answer2)];
+                    count = count - zbx_json_count(&jp_data);
+                }
                 free((void*) answer2);
                 zabbix_log(LOG_LEVEL_DEBUG, "Count of containers in %s status: %d", state, count);
                 SET_UI64_RESULT(result, count);
@@ -2143,10 +2159,15 @@ int     zbx_module_docker_cstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
                             SET_MSG_RESULT(result, strdup("docker.cstatus is not available at the moment - some problem with Docker's socket API"));
                             return SYSINFO_RET_FAIL;
                         }
-                        struct zbx_json_parse	jp_data;
-                        jp_data.start = &answer[0];
-                        jp_data.end = &answer[strlen(answer)];
-                        int count = zbx_json_count(&jp_data);
+                        if(strcmp(answer, "[]\n") == 0)
+                        {
+                            int count = 0;
+                        } else {
+                            struct zbx_json_parse	jp_data;
+                            jp_data.start = &answer[0];
+                            jp_data.end = &answer[strlen(answer)];
+                            int count = zbx_json_count(&jp_data);
+                        }
                         free((void*) answer);
                         zabbix_log(LOG_LEVEL_DEBUG, "Count of containers in %s status: %d", state, count);
                         SET_UI64_RESULT(result, count);

--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -2358,12 +2358,19 @@ int     zbx_module_docker_vstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
             }
 
             struct zbx_json_parse	jp_data, jp_data2;
+            int count;
             jp_data.start = &answer[0];
             jp_data.end = &answer[strlen(answer)];
 
             if (SUCCEED == zbx_json_brackets_by_name(&jp_data, "Volumes", &jp_data2)) {
-                int count = zbx_json_count(&jp_data2);
+                count = zbx_json_count(&jp_data2);
                 free((void*) answer);
+                zabbix_log(LOG_LEVEL_DEBUG, "Count of volumes in %s status: %d", state, count);
+                SET_UI64_RESULT(result, count);
+                return SYSINFO_RET_OK;
+            } else {
+                free((void*) answer);
+                count = 0;
                 zabbix_log(LOG_LEVEL_DEBUG, "Count of volumes in %s status: %d", state, count);
                 SET_UI64_RESULT(result, count);
                 return SYSINFO_RET_OK;
@@ -2386,12 +2393,19 @@ int     zbx_module_docker_vstatus(AGENT_REQUEST *request, AGENT_RESULT *result)
             }
 
             struct zbx_json_parse	jp_data, jp_data2;
+            int count;
             jp_data.start = &answer[0];
             jp_data.end = &answer[strlen(answer)];
 
             if (SUCCEED == zbx_json_brackets_by_name(&jp_data, "Volumes", &jp_data2)) {
-                int count = zbx_json_count(&jp_data2);
+                count = zbx_json_count(&jp_data2);
                 free((void*) answer);
+                zabbix_log(LOG_LEVEL_DEBUG, "Count of volumes in %s status: %d", state, count);
+                SET_UI64_RESULT(result, count);
+                return SYSINFO_RET_OK;
+            } else {
+                free((void*) answer);
+                count = 0;
                 zabbix_log(LOG_LEVEL_DEBUG, "Count of volumes in %s status: %d", state, count);
                 SET_UI64_RESULT(result, count);
                 return SYSINFO_RET_OK;

--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -165,10 +165,12 @@ const char*  zbx_module_docker_socket_query(char *query, int stream)
         }
 
         // socket input/output timeout
-        if (setsockopt (sock, SOL_SOCKET, SO_RCVTIMEO, (char *)&stimeout, sizeof(stimeout)) < 0) {
+        if (setsockopt (sock, SOL_SOCKET, SO_RCVTIMEO, (char *)&stimeout, sizeof(stimeout)) < 0)
+        {
             zabbix_log(LOG_LEVEL_WARNING, "Cannot set SO_RCVTIMEO socket timeout: %d seconds", stimeout.tv_sec);
         }
-        if (setsockopt (sock, SOL_SOCKET, SO_SNDTIMEO, (char *)&stimeout, sizeof(stimeout)) < 0) {
+        if (setsockopt (sock, SOL_SOCKET, SO_SNDTIMEO, (char *)&stimeout, sizeof(stimeout)) < 0)
+        {
             zabbix_log(LOG_LEVEL_WARNING, "Cannot set SO_SNDTIMEO socket timeout: %d seconds", stimeout.tv_sec);
         }
 


### PR DESCRIPTION
- official support for systemd has been removed
- fix for cstatus/vstatus/istatus
- Docker socket query timeout implementation
- new key `docker.modver`