### PR TITLE
Add Gitpod configuration

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+RUN sudo apt-get -q update && \
+    sudo apt-get install -yq autoconf automake bear && \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+tasks:
+- init: >-
+    git clone --quiet https://git.zabbix.com/scm/zbx/zabbix.git --depth 1 --single-branch --branch release/5.0 /workspace/zabbix/ &&
+    cd /workspace/zabbix &&
+    ./bootstrap.sh &&
+    ./configure --enable-agent &&
+    cd - &&
+    bear make -C src/modules/zabbix_module_docker ZABBIX_SOURCE=/workspace/zabbix
+image:
+  file: .gitpod.Dockerfile

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [<img src="https://monitoringartist.github.io/managed-by-monitoringartist.png" alt="Managed by Monitoring Artist: DevOps / Docker / Kubernetes / AWS ECS / Zabbix / Zenoss / Terraform / Monitoring" align="right"/>](http://www.monitoringartist.com 'DevOps / Docker / Kubernetes / AWS ECS / Zabbix / Zenoss / Terraform / Monitoring')
 
-# Zabbix Docker Monitoring [![Build Status](https://travis-ci.org/monitoringartist/zabbix-docker-monitoring.svg?branch=master)](https://travis-ci.org/monitoringartist/zabbix-docker-monitoring)
+# Zabbix Docker Monitoring [![Build Status](https://travis-ci.org/monitoringartist/zabbix-docker-monitoring.svg?branch=master)](https://travis-ci.org/monitoringartist/zabbix-docker-monitoring) [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/monitoringartist/zabbix-docker-monitoring)
 
 If you like or use this project, please provide feedback to author - Star it ★
 and [write what's missing for you](https://docs.google.com/forms/d/e/1FAIpQLSdYIokAyIMs2Qv19fzPxMWBubS9ESOYjJ2w_P222k5SuQuvoA/viewform).

--- a/src/modules/zabbix_module_docker/Makefile
+++ b/src/modules/zabbix_module_docker/Makefile
@@ -1,2 +1,4 @@
+ZABBIX_SOURCE = ../../..
+
 zabbix_module_docker: zabbix_module_docker.c
-	gcc -fPIC -shared -o zabbix_module_docker.so zabbix_module_docker.c -I../../../include -I../../../src/libs/zbxsysinfo
+	gcc -fPIC -shared -o zabbix_module_docker.so zabbix_module_docker.c -I$(ZABBIX_SOURCE)/include -I$(ZABBIX_SOURCE)/src/libs/zbxsysinfo


### PR DESCRIPTION
[Gitpod](https://www.gitpod.io) provides development environment in your browser.

To simplify integration with Gitpod and improve development experience in general, I've tweaked Makefile a bit to allow builds outside of Zabbix source tree:
```bash
$ make ZABBIX_SOURCE=/path/to/zabbix
```
In this case copying files to src/modules/ of Zabbix is not required. But by default Makefile will behave like before (and Travis CI config didn't change).