### PR TITLE
Fix a couple of compiler warnings

### DIFF
--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -690,7 +690,7 @@ int     zbx_docker_dir_detect()
             "libvirt/lxc/",   // Legacy libvirt-lxc
             // TODO pos = cgroup.find("-lxc\\x2");     // Systemd libvirt-lxc
             // TODO pos = cgroup.find(".libvirt-lxc"); // Non-systemd libvirt-lxc
-            ""
+            NULL
         }, **tdriver;
         char path[512];
         const char *mounts_regex = "^[^[:blank:]]+[[:blank:]]+(/[^[:blank:]]+/)[^[:blank:]]+[[:blank:]]+cgroup[[:blank:]]+.*$";
@@ -719,7 +719,7 @@ int     zbx_docker_dir_detect()
                 tdriver = drivers;
                 size_t  ddir_size;
                 char    *ddir;
-                while (*tdriver != "")
+                while (*tdriver != NULL)
                 {
                     ddir_size = strlen(cgroup) + strlen(stat_dir) + strlen(*tdriver) + 1;
                     ddir = malloc(ddir_size);
@@ -756,7 +756,7 @@ int     zbx_docker_dir_detect()
                         free(ddir);
                         return SYSINFO_RET_OK;
                     }
-                    *tdriver++;
+                    tdriver++;
                     free(ddir);
                 }
                 driver = "";


### PR DESCRIPTION
In the following code clang (via [clangd](https://clangd.llvm.org) language server in Gitpod) reports two warnings.
```c
char *drivers[] = {..., ""}, **tdriver;
...
tdriver = drivers;
...
while (*tdriver != "") /* Result of comparison against a string literal is unspecified (use an explicit string comparison function instead) */
{
    ...
    *tdriver++; /* Expression result unused */
    ...
}
```

1. "Result of comparison against a string literal is unspecified (use an explicit string comparison function instead)"
In C strings are arrays of characters and arrays are almost synonymous to pointers. In `while` condition on the left hand side we have `tdriver` which is a pointer to pointer to character being dereferenced using `*` yielding a pointer to character. On the right hand side we have an empty string literal `""` which is an array of character and here it decays to pointer to characters. So we have two pointers to characters and we compare them _as pointers_ while they are actually _strings_ (i.e. arrays of characters). To compare two arrays it is not enough to compare _where_ arrays are stored, you also need to compare _what_ is stored there. You can do this using [`strcmp()`](https://en.cppreference.com/w/c/string/byte/strcmp) for strings or [`memcmp()`](https://en.cppreference.com/w/c/string/byte/memcmp) for generic arrays. The code is probably working as expected because `tdriver` is used to iterate over `drivers` array of string. Iteration is over when `tdriver` points to a terminating `""` element. It is not guaranteed that both `""` literals are stored in one place, but compiler usually does a good job of compressing strings embedded in a binary. For example, if you had `"bar"` and `"foobar"` in in your program source, compiler would put only `"foobar"` into binary and `"bar"` would point to the second part of `"foobar"`. Anyway, I think it is less confusing to use `NULL` as terminating element in `drivers`.
2. "Expression result unused"
This one is easier. _Suffix/postfix increment_ `++` has higher [precedence](https://en.cppreference.com/w/c/language/operator_precedence) than _indirection (dereference)_ `*`, therefore increment is performed first and the result of it is dereferenced afterwards, but the result of dereferencing is not used, hence the warning. Removing `*` should not change how this code behaves.