### PR TITLE
Stop using AGENT_REQUEST for module's internal needs

### DIFF
--- a/src/modules/zabbix_module_docker/Makefile
+++ b/src/modules/zabbix_module_docker/Makefile
@@ -1,4 +1,4 @@
 ZABBIX_SOURCE = ../../..
 
 zabbix_module_docker: zabbix_module_docker.c
-	gcc -fPIC -shared -o zabbix_module_docker.so zabbix_module_docker.c -I$(ZABBIX_SOURCE)/include -I$(ZABBIX_SOURCE)/src/libs/zbxsysinfo
+	gcc -fPIC -shared -o zabbix_module_docker.so zabbix_module_docker.c -I$(ZABBIX_SOURCE)/include

--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -1528,7 +1528,6 @@ int     zbx_module_init()
 int     zbx_module_docker_inspect(AGENT_REQUEST *request, AGENT_RESULT *result)
 {
         zabbix_log(LOG_LEVEL_DEBUG, "In zbx_module_docker_inspect()");
-
         struct inspect_result iresult;
         iresult = zbx_module_docker_inspect_exec(get_rparam(request, 0), get_rparam(request, 1), get_rparam(request, 2), get_rparam(request, 3));
         if (iresult.return_code == SYSINFO_RET_OK) {

--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -336,7 +336,7 @@ struct inspect_result     zbx_module_docker_inspect_exec(const char *container, 
             return iresult;
         }
 
-        if (container == NULL && param1 == NULL)
+        if (container == NULL || param1 == NULL)
         {
                 zabbix_log(LOG_LEVEL_ERR, "Invalid number of parameters: %d",  (container != NULL) + (param1 != NULL));
                 iresult.value = zbx_strdup(NULL, "Invalid number of parameters");


### PR DESCRIPTION
By design, `AGENT_REQUEST` is a read-only structure from module's perspective. Module should not use Zabbix internal functions to fill or modify this structure. As we see, this is not good for forward compatibility with newer Zabbix versions.