### PR TITLE
Replace Zabbix JSON processing functions with Jansson library

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,5 +3,5 @@ FROM gitpod/workspace-full
 USER gitpod
 
 RUN sudo apt-get -q update && \
-    sudo apt-get install -yq autoconf automake bear && \
+    sudo apt-get install -yq autoconf automake bear libjansson-dev && \
     sudo rm -rf /var/lib/apt/lists/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 
 install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq -y wget autoconf automake gcc git make pkg-config
+  - sudo apt-get install -qq -y wget autoconf automake gcc git make pkg-config libjansson-dev
 
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -221,12 +221,12 @@ You have to compile the module if provided binary doesn't work on your system.
 Basic compilation steps (please use right Zabbix branch version):
 
 ```bash
-# Required CentOS/RHEL apps:   yum install -y wget autoconf automake gcc git pcre-devel
-# Required Debian/Ubuntu apps: apt-get install -y wget autoconf automake gcc git make pkg-config libpcre3-dev
-# Required Fedora apps:        dnf install -y wget autoconf automake gcc git make pcre-devel
-# Required openSUSE apps:      zypper install -y wget autoconf automake gcc git make pkg-config pcre-devel
+# Required CentOS/RHEL apps:   yum install -y wget autoconf automake gcc git pcre-devel jansson-devel
+# Required Debian/Ubuntu apps: apt-get install -y wget autoconf automake gcc git make pkg-config libpcre3-dev libjansson-dev
+# Required Fedora apps:        dnf install -y wget autoconf automake gcc git make pcre-devel jansson-devel
+# Required openSUSE apps:      zypper install -y wget autoconf automake gcc git make pkg-config pcre-devel libjansson-devel
 # Required Gentoo apps 1:      emerge net-misc/wget sys-devel/autoconf sys-devel/automake sys-devel/gcc
-# Required Gentoo apps 2:      emerge dev-vcs/git sys-devel/make dev-util/pkgconfig dev-libs/libpcre
+# Required Gentoo apps 2:      emerge dev-vcs/git sys-devel/make dev-util/pkgconfig dev-libs/libpcre dev-libs/jansson
 # Source, use your version:    git clone -b 4.2.2 --depth 1 https://github.com/zabbix/zabbix.git /usr/src/zabbix
 cd /usr/src/zabbix
 ./bootstrap.sh

--- a/src/modules/zabbix_module_docker/Makefile
+++ b/src/modules/zabbix_module_docker/Makefile
@@ -1,4 +1,4 @@
 ZABBIX_SOURCE = ../../..
 
 zabbix_module_docker: zabbix_module_docker.c
-	gcc -fPIC -shared -o zabbix_module_docker.so zabbix_module_docker.c -I$(ZABBIX_SOURCE)/include
+	gcc -fPIC -shared -o zabbix_module_docker.so zabbix_module_docker.c -I$(ZABBIX_SOURCE)/include `pkg-config --cflags --libs jansson`


### PR DESCRIPTION
Should resolve #133.

I managed to do some minor testing, but given that I have very little experience with this module more testing is required by more experienced users with real-world Docker/Zabbix setups.