### PR TITLE
Add VS Code extension for clangd in Gitpod environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# compiled module
+*.so
+
+# clangd cache
+.cache/
+
+# compilation database
+compile_commands.json

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,3 +8,7 @@ tasks:
     bear make -C src/modules/zabbix_module_docker ZABBIX_SOURCE=/workspace/zabbix
 image:
   file: .gitpod.Dockerfile
+
+vscode:
+  extensions:
+    - llvm-vs-code-extensions.vscode-clangd


### PR DESCRIPTION
[Gitpod switched default editor from Theia to VS Code](https://www.gitpod.io/blog/cloud-ide-history) and now [clangd extension](https://open-vsx.org/extension/llvm-vs-code-extensions/vscode-clangd) needs to be installed explicitly. Previously it was available with Theia editor out of the box.

I've also added a minimalistic `.gitignore` file to hide certain files and directories that should not be committed.